### PR TITLE
Added JSON response support

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,7 +40,7 @@ The configuration can contain the following properties:
 * `name` \<string\> **required**: Defines the name which is later displayed in HomeKit
 * `getUrl` \<string |  [urlObject](#urlobject)\> **required**: Defines the url 
 (and other properties when using an urlObject) to query the current temperature (in celsius) from the sensor. 
-It currently expects the http server to return a float ranging from 0-100 (step 0.1) leaving out any html markup.
+Expects JSON formatted response from server, and takes the value defined in config.json of Homebridge (for example `status.temperature` for `[{"status":{"temperature":"12"}}]`
 * `pullInterval` \<integer\> **optional**: The property expects an interval in **milliseconds** in which the plugin 
 pulls updates from your http device. For more information read [pulling updates](#the-pull-way).  
 

--- a/index.js
+++ b/index.js
@@ -65,7 +65,7 @@ HTTP_TEMPERATURE.prototype = {
         const informationService = new Service.AccessoryInformation();
 
         informationService
-            .setCharacteristic(Characteristic.Manufacturer, "Andreas Bauer")
+            .setCharacteristic(Characteristic.Manufacturer, "Andreas Bauer / 0101")
             .setCharacteristic(Characteristic.Model, "HTTP Temperature Sensor")
             .setCharacteristic(Characteristic.SerialNumber, "TS01")
             .setCharacteristic(Characteristic.FirmwareRevision, packageJSON.version);
@@ -105,8 +105,12 @@ HTTP_TEMPERATURE.prototype = {
                 callback(new Error("Got http error code " + response.statusCode));
             }
             else {
-                const temperature = parseFloat(body);
-                this.log("temperature is currently at %s", temperature);
+                var json = body;
+                var json = json.substring(1, json.length - 1);
+                var parsedJSON = JSON.parse(json)
+                var conf = config.jsonValue // Value from config here
+                var temperature = parsedJSON.conf
+                // this.log("Temperature is currently at %s", temperature);
 
                 callback(null, temperature);
             }


### PR DESCRIPTION
It takes value 'jsonValue' from config.json of Homebridge, dont know how to implement it though. The base for parsing value from JSON response is done, the only thing that requires work is the editing value in config file (we dont want people editing source file of plugin ;) )

Expects JSON formatted response from server, and takes the value defined in config.json of Homebridge (for example `status.temperature` for `[{"status":{"temperature":"12"}}]`