### PR TITLE
Don't write so many logs (when successfully anyway)

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,6 +43,7 @@ The configuration can contain the following properties:
 It currently expects the http server to return a float ranging from 0-100 (step 0.1) leaving out any html markup.
 * `pullInterval` \<integer\> **optional**: The property expects an interval in **milliseconds** in which the plugin 
 pulls updates from your http device. For more information read [pulling updates](#the-pull-way).  
+* `debug` \<boolean\> **optional**: Enable debug mode and write more logs.  
 
 Below are two example configurations. One is using a simple string url and the other is using a simple urlObject.  
 Both configs can be used for a basic plugin configuration.

--- a/index.js
+++ b/index.js
@@ -21,6 +21,7 @@ module.exports = function (homebridge) {
 function HTTP_TEMPERATURE(log, config) {
     this.log = log;
     this.name = config.name;
+    this.debug = config.debug || false;
 
     if (config.getUrl) {
         try {
@@ -106,7 +107,8 @@ HTTP_TEMPERATURE.prototype = {
             }
             else {
                 const temperature = parseFloat(body);
-                this.log("temperature is currently at %s", temperature);
+                if (this.debug)
+                    this.log("Temperature is currently at %s", temperature);
 
                 callback(null, temperature);
             }


### PR DESCRIPTION
For each temperature sensor, a log message is created on every poll: "Temperature is currently at ...".
Since this produces quite a lot of superfluous messages, this patch introduces a debug mode á la home bridge-http-switch and only creates those logs when it os switched on.